### PR TITLE
Restyle site to match Del's brand identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Del's — A Modern Speakeasy
+# Del's
 
-The website for Del's, a hidden cocktail bar behind an unmarked door. Dark,
-candlelit, art-deco styling with classic and original cocktail menus.
+The website for Del's — cocktails and light bites. Dark navy, hand-drawn
+tally-mark branding, and ink-sketch paper menus.
 
 Built with [Next.js](https://nextjs.org) (App Router) and
 [Tailwind CSS v4](https://tailwindcss.com).
@@ -24,13 +24,15 @@ Open [http://localhost:3000](http://localhost:3000).
 
 ## Design Notes
 
-- **Typography**: Great Vibes (script wordmark), Cinzel (engraved small-caps
-  labels), Cormorant Garamond (body), loaded via `next/font`.
-- **Palette**: near-black backgrounds with antique gold accents, defined as
-  CSS variables in `src/app/globals.css`.
-- **Art-deco details**: double-ruled frames (`.deco-frame`), diamond dividers
-  (`.deco-divider`), and dotted menu leaders (`.menu-leader`) are reusable
-  utility classes in `globals.css`.
+- **Typography**: Permanent Marker (wordmark), Architects Daughter (menu
+  handwriting), Space Mono (letterspaced labels), loaded via `next/font`;
+  Helvetica stack for body text.
+- **Palette**: dark navy background with off-white text and a rust-red
+  accent; paper-white menu sheets with black ink. Defined as CSS variables
+  in `src/app/globals.css`.
+- **Brand details**: the tally-mark motif is `src/app/components/hatch.tsx`;
+  hand-sketched glassware is `src/app/components/glass.tsx`; handwritten
+  underlines use the `.hand-rule` class in `globals.css`.
 
 ## Deploy
 

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,53 +1,69 @@
 import type { Metadata } from "next";
+import Hatch from "../components/hatch";
+import Glass from "../components/glass";
 
 export const metadata: Metadata = {
   title: "About — Del's",
-  description: "The story of Del's, a modern speakeasy hidden in plain sight.",
+  description: "Jesse Toporek, creator of Del's.",
 };
 
 export default function About() {
   return (
-    <div className="mx-auto max-w-3xl px-6 py-20">
-      <header className="flex flex-col items-center text-center">
-        <p className="deco-label text-gold">Our Story</p>
-        <h1 className="mt-4 text-5xl font-light md:text-6xl">
-          Hidden in Plain Sight
-        </h1>
-        <div className="deco-divider mt-8 w-40 text-gold">&#9670;</div>
-      </header>
+    <div className="mx-auto max-w-5xl px-6 py-20">
+      <div className="grid items-start gap-12 md:grid-cols-[2fr_3fr] md:gap-16">
+        {/* Photo slot — drop a b&w shot of Jesse into /public and wire it here */}
+        <div
+          className="flex aspect-3/4 items-center justify-center border border-line bg-surface"
+          style={{
+            backgroundImage:
+              "repeating-linear-gradient(45deg, transparent, transparent 10px, rgba(244,242,236,0.03) 10px, rgba(244,242,236,0.03) 11px)",
+          }}
+        >
+          <span className="mono-label text-muted">Photo</span>
+        </div>
 
-      <div className="mt-14 space-y-8 text-xl font-light leading-relaxed text-foreground/85">
-        <p>
-          Del&apos;s began the way most good ideas do: late at night, over a
-          drink that deserved better company. We wanted a room where the phones
-          stay in pockets, the ice is clear, and the bartender remembers what
-          you had last time &mdash; the kind of bar the 1920s had to invent
-          because the law left them no choice, and the kind we choose to keep
-          alive because nothing has replaced it.
-        </p>
-        <p>
-          There is no sign out front. The door is unmarked, the windows say
-          something else entirely, and we like it that way. Inside you&apos;ll
-          find forty seats, a back bar of spirits collected one bottle at a
-          time, and a menu that treats the classics with respect and everything
-          else with curiosity.
-        </p>
-        <p>
-          We take our drinks seriously and very little else. Come as you are,
-          stay as long as you like, and if anyone asks where you were tonight
-          &mdash; you were at the pictures.
-        </p>
+        <div>
+          <h1 className="flex flex-wrap items-baseline gap-x-4 gap-y-2">
+            <span className="headline text-2xl md:text-3xl">
+              Jesse Toporek
+            </span>
+            <span className="mono-label text-foreground/70">
+              Creator of Del&apos;s
+            </span>
+          </h1>
+
+          <Hatch strokes={10} className="mt-6 h-5 w-20 text-accent" />
+
+          <p className="mt-10 max-w-xl leading-relaxed text-foreground/80">
+            Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam
+            nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat
+            volutpat. Ut wisi enim ad minim veniam, quis nostrud exerci tation
+            ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo
+            consequat. Duis autem vel eum iriure dolor in hendrerit in
+            vulputate Lorem ipsum dolor sit amet, consectetuer adipiscing elit,
+            sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna
+            aliquam erat volutpat. Ut wisi enim ad minim veniam, quis nostrud
+            exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea
+            commodo consequat. Duis autem vel eum iriure dolor in hendrerit in
+            vulputate Lorem ipsum dolor sit amet, consectetuer adipiscing elit,
+            sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna
+            aliquam erat volutpat. Ut wisi enim ad minim veniam, quis nostrud
+            exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea
+            commodo consequat. Duis autem vel eum iriure dolor in hendrerit in
+            vulputate
+          </p>
+
+          <div className="mono-label mt-12 space-y-3 text-foreground/85">
+            <p>Favorite cocktail: XYZ</p>
+            <p>Favorite light bite: XYZ</p>
+          </div>
+
+          <div className="mt-10 flex gap-4 text-foreground/80">
+            <Glass variant="rocks" className="h-14 w-11" />
+            <Glass variant="coupe" className="h-14 w-11" />
+          </div>
+        </div>
       </div>
-
-      <section className="deco-frame mt-16 p-10 text-center">
-        <h2 className="deco-label text-gold">House Rules</h2>
-        <ul className="mt-6 space-y-3 text-lg font-light text-foreground/80">
-          <li>Speak easy &mdash; the room is small and the walls are thin.</li>
-          <li>No photography past the door. Memories only.</li>
-          <li>Don&apos;t bring anyone you wouldn&apos;t trust with a secret.</li>
-          <li>The bartender&apos;s choice is always a safe bet.</li>
-        </ul>
-      </section>
     </div>
   );
 }

--- a/src/app/components/footer.tsx
+++ b/src/app/components/footer.tsx
@@ -1,36 +1,34 @@
 import Link from "next/link";
+import Hatch from "./hatch";
 
 export default function Footer() {
   return (
     <footer className="border-t border-line">
       <div className="mx-auto flex max-w-5xl flex-col items-center gap-4 px-6 py-10 text-center">
-        <span className="script text-3xl text-gold">Del&apos;s</span>
-        <p className="deco-label text-muted">
-          Speak easy &middot; Drink well &middot; Tell no one
-        </p>
+        <span className="marker text-2xl">DEL&apos;S</span>
+        <Hatch strokes={14} className="h-4 w-24 text-foreground/60" />
         <nav className="flex gap-6">
           <Link
             href="/about"
-            className="deco-label text-foreground/60 transition-colors hover:text-gold-bright"
+            className="mono-label text-foreground/60 transition-colors hover:text-accent"
           >
             About
           </Link>
           <Link
             href="/menus"
-            className="deco-label text-foreground/60 transition-colors hover:text-gold-bright"
+            className="mono-label text-foreground/60 transition-colors hover:text-accent"
           >
             Menus
           </Link>
           <Link
             href="/contact"
-            className="deco-label text-foreground/60 transition-colors hover:text-gold-bright"
+            className="mono-label text-foreground/60 transition-colors hover:text-accent"
           >
             Contact
           </Link>
         </nav>
-        <p className="text-sm text-muted">
-          &copy; {new Date().getFullYear()} Del&apos;s. If you found us, keep it
-          quiet.
+        <p className="mono-label text-muted">
+          &copy; {new Date().getFullYear()} &middot; Del&apos;s
         </p>
       </div>
     </footer>

--- a/src/app/components/glass.tsx
+++ b/src/app/components/glass.tsx
@@ -1,0 +1,77 @@
+/* Loose pen-sketch glassware in the style of the printed menus.
+   Each variant is a set of open strokes drawn twice — the second pass is
+   nudged and faded to fake a hand-drawn double line. */
+
+const variants = {
+  collins: [
+    "M17 10 C26 14 36 14 45 10",
+    "M17 10 L19 70",
+    "M45 10 L43 70",
+    "M19 70 C27 74 35 74 43 70",
+    "M24 30 L25 64",
+  ],
+  rocks: [
+    "M14 24 C26 28 36 28 48 24",
+    "M14 24 L19 68",
+    "M48 24 L43 68",
+    "M19 68 C28 72 34 72 43 68",
+    "M25 50 L26 65",
+    "M31 52 L31 66",
+    "M37 50 L36 65",
+  ],
+  coupe: [
+    "M14 12 C25 16 37 16 48 12",
+    "M14 12 C14 28 22 36 31 36",
+    "M48 12 C48 28 40 36 31 36",
+    "M31 36 L31 62",
+    "M19 67 C27 63 35 63 43 67",
+    "M17 68 C27 72 35 72 45 68",
+  ],
+  wine: [
+    "M20 8 C27 11 35 11 42 8",
+    "M20 8 C20 26 25 33 31 33",
+    "M42 8 C42 26 37 33 31 33",
+    "M31 33 L31 60",
+    "M21 65 C28 61 34 61 41 65",
+    "M19 66 C28 70 34 70 43 66",
+  ],
+  soda: [
+    "M16 8 C26 12 36 12 46 8",
+    "M16 8 L21 70",
+    "M46 8 L41 70",
+    "M21 70 C28 74 34 74 41 70",
+    "M27 28 L29 64",
+  ],
+} as const;
+
+export type GlassVariant = keyof typeof variants;
+
+export default function Glass({
+  variant,
+  className = "",
+}: {
+  variant: GlassVariant;
+  className?: string;
+}) {
+  const paths = variants[variant];
+  return (
+    <svg
+      viewBox="0 0 62 80"
+      className={className}
+      aria-hidden
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+    >
+      {paths.map((d) => (
+        <path key={d} d={d} />
+      ))}
+      <g opacity={0.45} transform="translate(0.9 0.7) rotate(0.8 31 40)">
+        {paths.map((d) => (
+          <path key={d} d={d} strokeWidth={1.4} />
+        ))}
+      </g>
+    </svg>
+  );
+}

--- a/src/app/components/hatch.tsx
+++ b/src/app/components/hatch.tsx
@@ -1,0 +1,42 @@
+/* The Del's tally-mark motif: a row of hand-drawn vertical strokes.
+   Tilt/length variance is deterministic so server and client render match. */
+export default function Hatch({
+  strokes = 18,
+  className = "",
+}: {
+  strokes?: number;
+  className?: string;
+}) {
+  const tilts = [-4, 2, -1, 4, -3, 1, 3, -2, 0, 4, -4, 2, -1, 3, -3, 1, -2, 4];
+  const lengths = [22, 20, 23, 19, 22, 21, 20, 23, 21, 19, 22, 20, 23, 21, 20, 22, 19, 21];
+  const step = 7;
+  const width = strokes * step + 6;
+
+  return (
+    <svg
+      viewBox={`0 0 ${width} 30`}
+      className={className}
+      aria-hidden
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={3}
+      strokeLinecap="round"
+    >
+      {Array.from({ length: strokes }, (_, i) => {
+        const x = 5 + i * step;
+        const len = lengths[i % lengths.length];
+        const y1 = (30 - len) / 2;
+        return (
+          <line
+            key={i}
+            x1={x}
+            y1={y1}
+            x2={x}
+            y2={y1 + len}
+            transform={`rotate(${tilts[i % tilts.length]} ${x} 15)`}
+          />
+        );
+      })}
+    </svg>
+  );
+}

--- a/src/app/components/navbar.tsx
+++ b/src/app/components/navbar.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import Hatch from "./hatch";
 
 const links = [
   { href: "/about", label: "About" },
@@ -9,19 +10,19 @@ const links = [
 export default function Navbar() {
   return (
     <header className="border-b border-line">
-      <nav className="mx-auto flex max-w-5xl flex-col items-center gap-3 px-6 py-5 md:flex-row md:justify-between md:gap-8">
-        <Link
-          href="/"
-          className="script text-4xl text-gold transition-colors hover:text-gold-bright"
-        >
-          Del&apos;s
+      <nav className="mx-auto flex max-w-5xl flex-col items-center gap-4 px-6 py-5 md:flex-row md:justify-between">
+        <Link href="/" className="group flex flex-col items-center gap-1">
+          <span className="marker text-3xl leading-none transition-colors group-hover:text-accent">
+            DEL&apos;S
+          </span>
+          <Hatch strokes={12} className="h-3 w-20 text-accent" />
         </Link>
         <ul className="flex items-center gap-8 md:gap-10">
           {links.map(({ href, label }) => (
             <li key={href}>
               <Link
                 href={href}
-                className="deco-label text-foreground/80 transition-colors hover:text-gold-bright"
+                className="mono-label text-foreground/80 transition-colors hover:text-accent"
               >
                 {label}
               </Link>

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,66 +1,60 @@
 import type { Metadata } from "next";
+import Hatch from "../components/hatch";
 
 export const metadata: Metadata = {
   title: "Contact — Del's",
-  description:
-    "Hours, reservations, and how to find the unmarked door at Del's speakeasy.",
+  description: "Hours, reservations, and how to find Del's.",
 };
 
 export default function Contact() {
   return (
     <div className="mx-auto max-w-3xl px-6 py-20">
       <header className="flex flex-col items-center text-center">
-        <p className="deco-label text-gold">Contact</p>
-        <h1 className="mt-4 text-5xl font-light md:text-6xl">Find the Door</h1>
-        <div className="deco-divider mt-8 w-40 text-gold">&#9670;</div>
-        <p className="mt-6 max-w-md text-lg italic text-muted">
-          We don&apos;t advertise, and we like a little mystery. But we&apos;re
-          not impossible to reach.
-        </p>
+        <h1 className="headline text-2xl md:text-3xl">Contact</h1>
+        <Hatch strokes={10} className="mt-5 h-4 w-16 text-accent" />
       </header>
 
-      <div className="mt-16 grid gap-6 md:grid-cols-2">
-        <section className="deco-frame p-8 text-center">
-          <h2 className="deco-label text-gold">Hours</h2>
-          <dl className="mt-6 space-y-2 text-lg font-light text-foreground/85">
-            <div className="flex justify-between">
-              <dt>Wednesday &ndash; Thursday</dt>
+      <div className="mt-16 grid gap-12 md:grid-cols-2">
+        <section>
+          <h2 className="headline text-sm">Hours</h2>
+          <Hatch strokes={8} className="mt-3 h-3 w-14 text-accent" />
+          <dl className="mono-label mt-6 space-y-3 text-foreground/80">
+            <div className="flex justify-between gap-4">
+              <dt>Wed &ndash; Thu</dt>
               <dd>6 PM &ndash; 12 AM</dd>
             </div>
-            <div className="flex justify-between">
-              <dt>Friday &ndash; Saturday</dt>
+            <div className="flex justify-between gap-4">
+              <dt>Fri &ndash; Sat</dt>
               <dd>6 PM &ndash; 2 AM</dd>
             </div>
-            <div className="flex justify-between">
-              <dt>Sunday &ndash; Tuesday</dt>
-              <dd className="italic text-muted">Dark</dd>
+            <div className="flex justify-between gap-4">
+              <dt>Sun &ndash; Tue</dt>
+              <dd className="text-muted">Closed</dd>
             </div>
           </dl>
         </section>
 
-        <section className="deco-frame p-8 text-center">
-          <h2 className="deco-label text-gold">Reservations</h2>
-          <p className="mt-6 text-lg font-light leading-relaxed text-foreground/85">
-            Most of the room is walk-in, first come first seated. For parties
-            of five or more, write ahead:
+        <section>
+          <h2 className="headline text-sm">Reservations</h2>
+          <Hatch strokes={8} className="mt-3 h-3 w-14 text-accent" />
+          <p className="mt-6 leading-relaxed text-foreground/75">
+            Mostly walk-in, first come first seated. For larger parties, write
+            ahead:
           </p>
           <a
-            href="mailto:password@dels.bar"
-            className="mt-4 inline-block text-xl text-gold transition-colors hover:text-gold-bright"
+            href="mailto:hello@dels.bar"
+            className="mono-label mt-4 inline-block text-accent transition-colors hover:text-foreground"
           >
-            password@dels.bar
+            hello@dels.bar
           </a>
         </section>
 
-        <section className="deco-frame p-8 text-center md:col-span-2">
-          <h2 className="deco-label text-gold">Finding Us</h2>
-          <p className="mt-6 text-lg font-light leading-relaxed text-foreground/85">
-            Look for the green door with no sign, between the tailor and the
-            laundromat. If you&apos;ve reached the record shop, you&apos;ve
-            gone one door too far. Knock twice and tell them Del sent you.
-          </p>
-          <p className="mt-4 text-lg italic text-muted">
-            Lost? That&apos;s half the fun. But the email above works too.
+        <section className="md:col-span-2">
+          <h2 className="headline text-sm">Finding Us</h2>
+          <Hatch strokes={8} className="mt-3 h-3 w-14 text-accent" />
+          <p className="mt-6 max-w-xl leading-relaxed text-foreground/75">
+            No sign out front &mdash; look for the tally marks on the door.
+            If you&apos;re lost, the email above works.
           </p>
         </section>
       </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,30 +1,28 @@
 @import "tailwindcss";
 
 :root {
-  --background: #100e0b;
-  --surface: #17140f;
-  --surface-raised: #1e1a13;
-  --foreground: #ece3d0;
-  --muted: #9b9080;
-  --gold: #c9a25b;
-  --gold-bright: #e3c284;
-  --gold-dim: #8a6f3e;
-  --line: rgba(201, 162, 91, 0.25);
+  --background: #171a2b;
+  --surface: #1d2033;
+  --foreground: #f4f2ec;
+  --muted: #9a9db1;
+  --accent: #b5401f;
+  --paper: #f7f5f0;
+  --ink: #161616;
+  --line: rgba(244, 242, 236, 0.14);
 }
 
 @theme inline {
   --color-background: var(--background);
   --color-surface: var(--surface);
-  --color-surface-raised: var(--surface-raised);
   --color-foreground: var(--foreground);
   --color-muted: var(--muted);
-  --color-gold: var(--gold);
-  --color-gold-bright: var(--gold-bright);
-  --color-gold-dim: var(--gold-dim);
+  --color-accent: var(--accent);
+  --color-paper: var(--paper);
+  --color-ink: var(--ink);
   --color-line: var(--line);
-  --font-serif: var(--font-cormorant);
-  --font-script: var(--font-script);
-  --font-caps: var(--font-cinzel);
+  --font-mono: var(--font-space-mono);
+  --font-marker: var(--font-marker);
+  --font-hand: var(--font-hand);
 }
 
 html {
@@ -34,83 +32,64 @@ html {
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: var(--font-cormorant), Georgia, serif;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   min-height: 100dvh;
-  /* Faint candlelight glow behind the content */
-  background-image: radial-gradient(
-      ellipse 80% 50% at 50% -10%,
-      rgba(201, 162, 91, 0.08),
-      transparent 70%
-    ),
-    radial-gradient(
-      ellipse 60% 40% at 50% 110%,
-      rgba(201, 162, 91, 0.05),
-      transparent 70%
-    );
 }
 
 ::selection {
-  background: var(--gold);
-  color: var(--background);
+  background: var(--accent);
+  color: var(--foreground);
 }
 
-/* Engraved small-caps labels used for nav links, section eyebrows, buttons */
-.deco-label {
-  font-family: var(--font-cinzel), Georgia, serif;
+/* Letterspaced uppercase mono — labels, nav, stats lines */
+.mono-label {
+  font-family: var(--font-space-mono), monospace;
   text-transform: uppercase;
-  letter-spacing: 0.28em;
+  letter-spacing: 0.3em;
   font-size: 0.72rem;
 }
 
-/* The Del's script wordmark */
-.script {
-  font-family: var(--font-script), cursive;
+/* Wide-tracked bold headline caps, like "JESSE TOPOREK" */
+.headline {
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  font-weight: 700;
 }
 
-/* Gold hairline with a diamond at the center: ────◆──── */
-.deco-divider {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  color: var(--gold);
-}
-.deco-divider::before,
-.deco-divider::after {
-  content: "";
-  flex: 1;
-  height: 1px;
-  background: linear-gradient(to var(--dir, right), transparent, var(--line));
-}
-.deco-divider::before {
-  --dir: right;
-}
-.deco-divider::after {
-  --dir: left;
+/* Hand-drawn marker wordmark */
+.marker {
+  font-family: var(--font-marker), cursive;
 }
 
-/* Double-ruled art deco frame for cards and panels */
-.deco-frame {
+/* Architect-print handwriting used on the paper menus */
+.hand {
+  font-family: var(--font-hand), cursive;
+}
+
+/* Handwritten menu-item underline with tick ends */
+.hand-rule {
   position: relative;
-  border: 1px solid var(--line);
-  background: var(--surface);
+  display: inline-block;
+  padding-bottom: 2px;
+  border-bottom: 2px solid currentColor;
 }
-.deco-frame::before {
+.hand-rule::before,
+.hand-rule::after {
   content: "";
   position: absolute;
-  inset: 6px;
-  border: 1px solid rgba(201, 162, 91, 0.12);
-  pointer-events: none;
+  bottom: -4px;
+  width: 2px;
+  height: 8px;
+  background: currentColor;
+  transform: rotate(18deg);
+}
+.hand-rule::before {
+  left: -2px;
+}
+.hand-rule::after {
+  right: -2px;
 }
 
-/* Dotted leader between a menu item's name and price */
-.menu-leader {
-  flex: 1;
-  margin: 0 0.6em;
-  border-bottom: 1px dotted rgba(201, 162, 91, 0.35);
-  transform: translateY(-0.35em);
-}
-
-/* Slow fade-up for hero content */
 @keyframes rise {
   from {
     opacity: 0;
@@ -122,10 +101,10 @@ body {
   }
 }
 .rise {
-  animation: rise 0.9s ease-out both;
+  animation: rise 0.8s ease-out both;
 }
 .rise-late {
-  animation: rise 0.9s ease-out 0.35s both;
+  animation: rise 0.8s ease-out 0.3s both;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,33 +1,35 @@
 import type { Metadata } from "next";
-import { Cormorant_Garamond, Cinzel, Great_Vibes } from "next/font/google";
+import {
+  Space_Mono,
+  Permanent_Marker,
+  Architects_Daughter,
+} from "next/font/google";
 import "./globals.css";
 
 import Navbar from "./components/navbar";
 import Footer from "./components/footer";
 
-const cormorant = Cormorant_Garamond({
-  variable: "--font-cormorant",
+const spaceMono = Space_Mono({
+  variable: "--font-space-mono",
   subsets: ["latin"],
-  weight: ["300", "400", "500", "600"],
-  style: ["normal", "italic"],
+  weight: ["400", "700"],
 });
 
-const cinzel = Cinzel({
-  variable: "--font-cinzel",
+const marker = Permanent_Marker({
+  variable: "--font-marker",
   subsets: ["latin"],
-  weight: ["400", "500"],
+  weight: "400",
 });
 
-const greatVibes = Great_Vibes({
-  variable: "--font-script",
+const hand = Architects_Daughter({
+  variable: "--font-hand",
   subsets: ["latin"],
   weight: "400",
 });
 
 export const metadata: Metadata = {
-  title: "Del's — A Modern Speakeasy",
-  description:
-    "Del's is a hidden cocktail bar pouring classic and original cocktails behind an unmarked door. Find us if you can.",
+  title: "Del's",
+  description: "Del's — cocktails and light bites.",
 };
 
 export default function RootLayout({
@@ -38,7 +40,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${cormorant.variable} ${cinzel.variable} ${greatVibes.variable} antialiased flex min-h-dvh flex-col`}
+        className={`${spaceMono.variable} ${marker.variable} ${hand.variable} antialiased flex min-h-dvh flex-col`}
       >
         <Navbar />
         <main className="flex-1">{children}</main>

--- a/src/app/menus/page.tsx
+++ b/src/app/menus/page.tsx
@@ -1,176 +1,122 @@
 import type { Metadata } from "next";
+import Hatch from "../components/hatch";
+import Glass, { type GlassVariant } from "../components/glass";
 
 export const metadata: Metadata = {
   title: "Menus — Del's",
-  description:
-    "Classic and original cocktails, zero-proof drinks, and small plates at Del's speakeasy.",
+  description: "Cocktails and light bites at Del's.",
 };
 
-type Item = {
-  name: string;
-  detail: string;
-  price: string;
-};
-
-type Section = {
-  title: string;
-  note?: string;
-  items: Item[];
-};
-
-const sections: Section[] = [
+const cocktails: { name: string; detail: string; glass: GlassVariant }[] = [
   {
-    title: "House Cocktails",
-    note: "Originals, poured until the shaker gives out.",
-    items: [
-      {
-        name: "The Unmarked Door",
-        detail: "rye, walnut bitters, demerara, smoked glass",
-        price: "17",
-      },
-      {
-        name: "Green Light",
-        detail: "gin, chartreuse, lime, celery shrub",
-        price: "16",
-      },
-      {
-        name: "Midnight Edition",
-        detail: "mezcal, coffee liqueur, cacao, orange oil",
-        price: "17",
-      },
-      {
-        name: "Del's Word",
-        detail: "our take on the Last Word — gin, maraschino, lime, yellow chartreuse",
-        price: "16",
-      },
-      {
-        name: "Paper Alibi",
-        detail: "bourbon, amaro, lemon, honey, dash of absinthe",
-        price: "16",
-      },
-    ],
+    name: "Aperitivo",
+    detail: "vermouth, soda, lemon twist",
+    glass: "collins",
   },
   {
-    title: "The Classics",
-    note: "Made the way they were before anyone wrote them down wrong.",
-    items: [
-      {
-        name: "Old Fashioned",
-        detail: "bourbon or rye, sugar, bitters, one big rock",
-        price: "15",
-      },
-      {
-        name: "Bee's Knees",
-        detail: "gin, honey, lemon — a Prohibition original",
-        price: "14",
-      },
-      {
-        name: "French 75",
-        detail: "gin, lemon, sugar, champagne",
-        price: "16",
-      },
-      {
-        name: "Sidecar",
-        detail: "cognac, cointreau, lemon, sugared rim",
-        price: "16",
-      },
-      {
-        name: "Corpse Reviver No. 2",
-        detail: "gin, lillet blanc, cointreau, lemon, absinthe rinse",
-        price: "15",
-      },
-    ],
+    name: "S.G.D.",
+    detail: "sake, gin, green chartreuse, sugar, lemon, grapefruit twist",
+    glass: "rocks",
   },
   {
-    title: "Zero Proof",
-    note: "All of the ceremony, none of the evidence.",
-    items: [
-      {
-        name: "Teetotaler's Sour",
-        detail: "seedlip grove, lemon, orgeat, aquafaba",
-        price: "11",
-      },
-      {
-        name: "Shirley's Temple",
-        detail: "house grenadine, lime, soda, brandied cherry",
-        price: "9",
-      },
-      {
-        name: "Garden Party",
-        detail: "cucumber, mint, tonic, celery bitters",
-        price: "10",
-      },
-    ],
+    name: "Roman Negroni",
+    detail: "mezcal, vermouth bianco, genepy, amaro, orange twist",
+    glass: "rocks",
   },
   {
-    title: "Small Plates",
-    note: "Enough to keep you honest.",
-    items: [
-      {
-        name: "Deviled Eggs",
-        detail: "smoked paprika, chive, pickled mustard seed",
-        price: "9",
-      },
-      {
-        name: "Olives & Almonds",
-        detail: "castelvetrano, marcona, orange peel",
-        price: "8",
-      },
-      {
-        name: "Charcuterie Board",
-        detail: "rotating cuts, aged cheese, house pickles, bread",
-        price: "22",
-      },
-      {
-        name: "Chocolate Pot de Crème",
-        detail: "dark chocolate, sea salt, whipped cream",
-        price: "10",
-      },
-    ],
+    name: "Del's June Martini",
+    detail:
+      "olive oil fat washed dill-infused gin, vermouth bianco, bitters, feta, tomato",
+    glass: "wine",
+  },
+  {
+    name: "Limoncello Milk Punch",
+    detail:
+      "limoncello, white rum, genepy, amaro, brandy, earl grey tea, lemon, bitters, milk",
+    glass: "rocks",
+  },
+  {
+    name: "Del's Iced Tea",
+    detail: "black tea, lemon, sugar",
+    glass: "rocks",
+  },
+  {
+    name: "The Coke",
+    detail: "amaro, ginger liquor, soda, lemon twist",
+    glass: "soda",
   },
 ];
 
+const bites = [
+  { name: "Crunchy", detail: "sea salt & vinegar chips" },
+  { name: "Briney", detail: "marinated olives, pickles, & peppers" },
+  { name: "Savory", detail: "aged manchego" },
+  { name: "Spicy", detail: "chorizo picante" },
+  { name: "Sweet", detail: "coffee chip ice cream & brandy" },
+];
+
+function PaperHeader() {
+  return (
+    <div className="flex flex-col items-center">
+      <span className="marker text-4xl">DEL&apos;S</span>
+      <Hatch strokes={14} className="mt-2 h-6 w-32" />
+    </div>
+  );
+}
+
 export default function Menus() {
   return (
-    <div className="mx-auto max-w-3xl px-6 py-20">
+    <div className="mx-auto max-w-4xl px-6 py-20">
       <header className="flex flex-col items-center text-center">
-        <p className="deco-label text-gold">The Menus</p>
-        <h1 className="mt-4 text-5xl font-light md:text-6xl">
-          Tonight&apos;s Pour
-        </h1>
-        <div className="deco-divider mt-8 w-40 text-gold">&#9670;</div>
-        <p className="mt-6 max-w-md text-lg italic text-muted">
-          The list changes with the seasons and the bartender&apos;s mood.
-          Ask what&apos;s off the menu.
+        <p className="mono-label text-foreground/80">The Menus</p>
+        <Hatch strokes={10} className="mt-4 h-4 w-16 text-accent" />
+        <p className="mono-label mt-6 text-muted">
+          The list rotates &mdash; every menu is dated, drawn, and retired
         </p>
       </header>
 
-      <div className="mt-16 space-y-14">
-        {sections.map(({ title, note, items }) => (
-          <section key={title} className="deco-frame p-8 md:p-12">
-            <h2 className="deco-label text-center text-gold">{title}</h2>
-            {note && (
-              <p className="mt-3 text-center text-lg italic text-muted">
-                {note}
+      {/* Cocktails — a printed sheet */}
+      <section className="mt-14 bg-paper p-8 text-ink shadow-2xl md:p-14">
+        <PaperHeader />
+        <ul className="mt-12 grid gap-x-12 gap-y-12 md:grid-cols-2">
+          {cocktails.map(({ name, detail, glass }, i) => (
+            <li
+              key={name}
+              className={`flex items-start gap-5 ${
+                i === cocktails.length - 1 ? "md:col-span-2 md:justify-center" : ""
+              }`}
+            >
+              <Glass variant={glass} className="h-16 w-12 shrink-0" />
+              <div>
+                <h2 className="hand hand-rule text-2xl uppercase">{name}</h2>
+                <p className="hand mt-2 text-lg uppercase leading-snug text-ink/80">
+                  {detail}
+                </p>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      {/* Light bites — a second sheet */}
+      <section className="mt-10 bg-paper p-8 text-ink shadow-2xl md:p-14">
+        <PaperHeader />
+        <ul className="mt-12 grid gap-x-12 gap-y-10 md:grid-cols-2">
+          {bites.map(({ name, detail }, i) => (
+            <li
+              key={name}
+              className={`text-center ${
+                i === bites.length - 1 ? "md:col-span-2" : ""
+              }`}
+            >
+              <h2 className="hand hand-rule text-2xl uppercase">{name}</h2>
+              <p className="hand mt-2 text-lg uppercase leading-snug text-ink/80">
+                {detail}
               </p>
-            )}
-            <ul className="mt-8 space-y-6">
-              {items.map(({ name, detail, price }) => (
-                <li key={name}>
-                  <div className="flex items-baseline text-xl">
-                    <span className="font-medium">{name}</span>
-                    <span className="menu-leader" aria-hidden />
-                    <span className="text-gold">{price}</span>
-                  </div>
-                  <p className="mt-1 text-lg font-light italic text-foreground/60">
-                    {detail}
-                  </p>
-                </li>
-              ))}
-            </ul>
-          </section>
-        ))}
-      </div>
+            </li>
+          ))}
+        </ul>
+      </section>
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,69 +1,67 @@
 import Link from "next/link";
+import Hatch from "./components/hatch";
 
 export default function Home() {
   return (
     <div className="mx-auto max-w-5xl px-6">
-      {/* Hero */}
-      <section className="flex flex-col items-center py-24 text-center md:py-36">
-        <p className="deco-label rise text-gold">Est. behind an unmarked door</p>
-        <h1 className="script rise mt-6 text-8xl leading-none text-gold-bright md:text-9xl">
-          Del&apos;s
+      {/* Hero — the wordmark lockup */}
+      <section className="flex flex-col items-center py-24 text-center md:py-32">
+        <h1 className="marker rise text-7xl leading-none md:text-9xl">
+          DEL&apos;S
         </h1>
-        <div className="deco-divider rise mt-8 w-48">&#9670;</div>
-        <p className="rise-late mt-8 max-w-xl text-2xl font-light italic text-foreground/85">
-          A modern speakeasy pouring forgotten classics and original cocktails
-          by candlelight.
+        <Hatch strokes={18} className="rise mt-6 h-8 w-56 md:h-10 md:w-72" />
+        <p className="mono-label rise-late mt-10 text-foreground/80">
+          Cocktails &amp; Light Bites
         </p>
         <div className="rise-late mt-12 flex flex-col items-center gap-4 sm:flex-row">
           <Link
             href="/menus"
-            className="deco-label border border-gold px-8 py-4 text-gold transition-colors hover:bg-gold hover:text-background"
+            className="mono-label border border-foreground px-8 py-4 transition-colors hover:border-accent hover:bg-accent"
           >
-            View the Menus
+            The Menu
           </Link>
           <Link
-            href="/contact"
-            className="deco-label px-8 py-4 text-foreground/70 transition-colors hover:text-gold-bright"
+            href="/about"
+            className="mono-label px-8 py-4 text-foreground/70 transition-colors hover:text-accent"
           >
-            Find the Door
+            About Del&apos;s
           </Link>
         </div>
       </section>
 
-      {/* Three promises */}
-      <section className="grid gap-6 pb-24 md:grid-cols-3">
+      {/* What's pouring — ticker line from the current menu */}
+      <section className="border-y border-line py-6 text-center">
+        <Link
+          href="/menus"
+          className="mono-label leading-8 text-muted transition-colors hover:text-accent"
+        >
+          Aperitivo &middot; S.G.D. &middot; Roman Negroni &middot; June Martini
+          &middot; Limoncello Milk Punch &middot; Iced Tea &middot; The Coke
+        </Link>
+      </section>
+
+      {/* The pitch */}
+      <section className="grid gap-12 py-20 md:grid-cols-3 md:gap-8">
         {[
           {
-            title: "The Craft",
-            body: "House syrups, hand-cut ice, and spirits chosen with a librarian's patience. Every drink is built, not poured.",
+            title: "The Drinks",
+            body: "Classics kept honest, plus house originals like the S.G.D. and the June Martini. The list rotates — every menu is dated, drawn, and retired.",
+          },
+          {
+            title: "The Bites",
+            body: "Five bowls, five moods: crunchy, briney, savory, spicy, sweet. Enough to keep you going without slowing you down.",
           },
           {
             title: "The Room",
-            body: "Low light, low ceilings, and a record player that has opinions. Forty seats, and not one of them bad.",
-          },
-          {
-            title: "The Rule",
-            body: "What happens at Del's stays at Del's. Photographs are discouraged; good stories are mandatory.",
+            body: "Small space, loud records, good company. Come thirsty, leave a regular.",
           },
         ].map(({ title, body }) => (
-          <article key={title} className="deco-frame p-8 text-center">
-            <h2 className="deco-label text-gold">{title}</h2>
-            <p className="mt-4 text-lg font-light leading-relaxed text-foreground/80">
-              {body}
-            </p>
+          <article key={title} className="flex flex-col items-center text-center md:items-start md:text-left">
+            <h2 className="headline text-sm">{title}</h2>
+            <Hatch strokes={8} className="mt-3 h-3 w-14 text-accent" />
+            <p className="mt-5 leading-relaxed text-foreground/75">{body}</p>
           </article>
         ))}
-      </section>
-
-      {/* Hours strip */}
-      <section className="deco-frame mb-24 flex flex-col items-center gap-3 p-10 text-center">
-        <h2 className="deco-label text-gold">Hours</h2>
-        <p className="text-xl font-light text-foreground/85">
-          Wednesday &ndash; Saturday &middot; 6 PM until late
-        </p>
-        <p className="text-lg italic text-muted">
-          Knock twice. Ask for Del.
-        </p>
       </section>
     </div>
   );


### PR DESCRIPTION
Replace the art-deco speakeasy look with the actual brand: dark navy with off-white text and rust-red accents, hand-drawn marker wordmark, tally-mark motif, letterspaced mono labels, and ink-on-paper menus.

- New Hatch component recreating the tally-mark motif as SVG
- New Glass component with pen-sketch glassware for the menus
- Fonts: Permanent Marker (wordmark), Architects Daughter (menu handwriting), Space Mono (labels); Helvetica stack for body
- About page rebuilt on the Jesse Toporek creator layout (photo slot, bio, favorite cocktail/light bite lines, sketch icons)
- Menus rebuilt as white paper sheets with the real cocktail and light-bite lists (Aperitivo, S.G.D., Roman Negroni, June Martini, Limoncello Milk Punch, Iced Tea, The Coke; Crunchy/Briney/Savory/ Spicy/Sweet)
- Home, contact, navbar, footer, and README updated to match


Claude-Session: https://claude.ai/code/session_018dVbZnDtYpa38vbvJ4sksX